### PR TITLE
fix division by zero on 32bit

### DIFF
--- a/src/zippy.nim
+++ b/src/zippy.nim
@@ -153,7 +153,7 @@ func uncompress(
     if checksum != crc32(dst):
       raise newException(ZippyError, "Checksum verification failed")
 
-    if isize != (dst.len mod (1 shl 32)).uint32:
+    if isize != (dst.len mod (1 shl 31)).uint32:
       raise newException(ZippyError, "Size verification failed")
   of dfZlib:
     if src.len < 6:


### PR DESCRIPTION
I got crash when trying to uncompress on 32bit machine