### PR TITLE
Added ability to extract zipfiles from stream in memory

### DIFF
--- a/zippy.nimble
+++ b/zippy.nimble
@@ -1,4 +1,4 @@
-version       = "0.5.3"
+version       = "0.5.4"
 author        = "Ryan Oldenburg"
 description   = "Pure Nim implementation of deflate, zlib, gzip and zip."
 license       = "MIT"


### PR DESCRIPTION
From #5, this allows you to extract zip files from an in-memory stream.

I also exposed the `clear()` method so that we can free up memory after it's extracted.

Example:

```nim
import os
import zippy/ziparchives
import streams

let ZIPFILE = slurp("archive.zip")

var archive = ZipArchive()
let zipStream = newStringStream(ZIPFILE)

archive.open(zipStream)
archive.extractAll(getCurrentDir() / "extractfolder")
archive.clear()
```