### PR TITLE
add .gitattributes to prevent automatic EOL conversion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# prevent automatic EOL conversion by git
+# on test data, because it will make test
+# failed
+
+tests/data/* binary
+


### PR DESCRIPTION
if we don't prevent automatic EOL conversion by git
on `tests/data`, the test will fail on Windows.