### PR TITLE
Tests multi nim versions on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,21 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        nim-version: ['1.0.0', '1.0.x', '1.2.x', '1.4.x', 'stable']
+        include:
+          - nim-version: '1.4.x'
+            gc_orc: true
+          - nim-version: 'stable'
+            gc_orc: true
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
     - uses: jiro4989/setup-nim-action@v1
+      with:
+        nim-version: ${{ matrix.nim-version }}
     - run: nimble test -d:release -y
     - run: nimble test --gc:orc -d:release -y
+      if: ${{ matrix.gc_orc }}
     - run: nim cpp -d:release -r tests/all.nim


### PR DESCRIPTION
Added 4 test cases to CI because `zippy` requires `nim >= 1.0.0` (https://github.com/guzba/zippy/blob/master/zippy.nimble#L8).

Test cases:

1. Build with Nim 1.0.0
2. Build with Nim 1.0.x ( `x` is a latest patch version)
3. Build with Nim 1.2.x
4. Build with Nim 1.4.x

But tests failes in Nim `1.0.0`, `1.0.x`, `1.2.x` ...

- [GitHub Actions Log](https://github.com/jiro4989/zippy/runs/3808613624?check_suite_focus=true)