### PR TITLE
Handle entries ending with / as directories

### DIFF
--- a/src/zippy/ziparchives.nim
+++ b/src/zippy/ziparchives.nim
@@ -1,5 +1,5 @@
-import common, crc, internal, std/memfiles, std/os, std/tables, std/times,
-    std/unicode, ziparchives_v1, zippy
+import common, crc, internal, std/memfiles, std/os, std/strutils, std/tables,
+    std/times, std/unicode, ziparchives_v1, zippy
 
 export common, ziparchives_v1
 
@@ -296,7 +296,7 @@ proc openZipArchive*(
         dosDirectoryFlag = (externalFileAttr and 0x10) != 0
         unixDirectoryFlag = (externalFileAttr and (S_IFDIR.uint32 shl 16)) != 0
         recordKind =
-          if dosDirectoryFlag or unixDirectoryFlag:
+          if dosDirectoryFlag or unixDirectoryFlag or utf8FileName.endsWith("/"):
             DirectoryRecord
           else:
             FileRecord


### PR DESCRIPTION
Currently, zip files with entries where neither the DOS nor the Unix directory flag is set, but are in reality directories (as indicated by paths ending with `/`) fail to be extracted, as the directories are erroneously identified as `FileRecord`. Such a zip file can be found here, for example: https://github.com/odin-lang/Odin/releases/download/dev-2022-08/odin-ubuntu-amd64-dev-2022-08.zip

This PR adds an extra check for such entries - if the filename ends with `/`, assume it is a `DirectoryRecord`.