### PR TITLE
Fix arm64 type mismatch build error

### DIFF
--- a/src/zippy/adler32_simd.nim
+++ b/src/zippy/adler32_simd.nim
@@ -128,7 +128,7 @@ elif defined(arm64):
     uint32x4 {.importc: "uint32x4_t".} = object
     uint8x8 {.importc: "uint8x8_t".} = object
     uint16x4 {.importc: "uint16x4_t".} = object
-    uint32x2 {.importc: "uint8x8_t".} = object
+    uint32x2 {.importc: "uint32x2_t".} = object
 
   func vmovq_n_u32(a: uint32): uint32x4
   func vmovq_n_u16(a: uint16): uint16x8


### PR DESCRIPTION
`uint8x8_t` is imported as `uint32x2`. Not sure if this is just a typo or if there was some deeper reasoning behind it, but this fixes the build for me. I'm running Debian 11 on an ARM EC2 instance.

Original error I was seeing:

```
/home/nitter/.cache/nim/nitter_r/@m..@s..@s.nimble@spkgs@szippy-@hc51399f@szippy@sadler32_simd.nim.c: In function ‘adler32_neon__OOZOOZOnimbleZpkgsZzippy4535c5349515757fZzippyZadler515095simd_63’:
/home/nitter/.cache/nim/nitter_r/@m..@s..@s.nimble@spkgs@szippy-@hc51399f@szippy@sadler32_simd.nim.c:525:4: note: use ‘-flax-vector-conversions’ to permit conversions between vectors with differing element types or numbers of subparts
  525 |    T41_ = vget_low_u32(vecS1);
      |    ^~~~
/home/nitter/.cache/nim/nitter_r/@m..@s..@s.nimble@spkgs@szippy-@hc51399f@szippy@sadler32_simd.nim.c:525:11: error: incompatible types when assigning to type ‘uint8x8_t’ from type ‘uint32x2_t’
  525 |    T41_ = vget_low_u32(vecS1);
      |           ^~~~~~~~~~~~
/home/nitter/.cache/nim/nitter_r/@m..@s..@s.nimble@spkgs@szippy-@hc51399f@szippy@sadler32_simd.nim.c:526:11: error: incompatible types when assigning to type ‘uint8x8_t’ from type ‘uint32x2_t’
  526 |    T42_ = vget_high_u32(vecS1);
      |           ^~~~~~~~~~~~~
/home/nitter/.cache/nim/nitter_r/@m..@s..@s.nimble@spkgs@szippy-@hc51399f@szippy@sadler32_simd.nim.c:527:21: error: incompatible type for argument 1 of ‘vpadd_u32’
  527 |    sum1 = vpadd_u32(T41_, T42_);
      |                     ^~~~
      |                     |
      |                     uint8x8_t
In file included from /home/nitter/.cache/nim/nitter_r/@m..@s..@s.nimble@spkgs@szippy-@hc51399f@szippy@sadler32_simd.nim.c:9:
/usr/lib/gcc/aarch64-linux-gnu/10/include/arm_neon.h:23265:23: note: expected ‘uint32x2_t’ but argument is of type ‘uint8x8_t’
23265 | vpadd_u32 (uint32x2_t __a, uint32x2_t __b)
      |            ~~~~~~~~~~~^~~
compilation terminated due to -fmax-errors=3.
Error: execution of an external compiler program 'gcc -c  -w -fmax-errors=3 -O3 -fno-strict-aliasing -fno-ident   -I/usr/lib/nim -I/home/nitter/nitter/src -o /home/nitter/.cache/nim/nitter_r/@m..@s..@s.nimble@spkgs@szippy-@hc51399f@szippy@sadler32_simd.nim.c.o /home/nitter/.cache/nim/nitter_r/@m..@s..@s.nimble@spkgs@szippy-@hc51399f@szippy@sadler32_simd.nim.c' failed with exit code: 1
```