### PR TITLE
Fix spelling of localPassC pragma

### DIFF
--- a/src/zippy/adler32_simd.nim
+++ b/src/zippy/adler32_simd.nim
@@ -13,7 +13,7 @@ const
 
 when defined(amd64):
   when defined(gcc) or defined(clang):
-    {.localPassc: "-mssse3".}
+    {.localPassC: "-mssse3".}
 
   {.push header: "emmintrin.h".}
 

--- a/src/zippy/crc32_simd.nim
+++ b/src/zippy/crc32_simd.nim
@@ -7,7 +7,7 @@
 
 when defined(amd64):
   when defined(gcc) or defined(clang):
-    {.localPassc: "-msse4.1 -mpclmul".}
+    {.localPassC: "-msse4.1 -mpclmul".}
 
   {.push header: "emmintrin.h".}
 


### PR DESCRIPTION
Allow compilation with parameters `--styleCheck:usages --styleCheck:error`.