### PR TITLE
fix: integer-overflow on arm 32-bit systems

### DIFF
--- a/src/zippy/ziparchives.nim
+++ b/src/zippy/ziparchives.nim
@@ -383,7 +383,7 @@ proc openZipArchive*(
         compressedSize: compressedSize,
         uncompressedSize: uncompressedSize,
         uncompressedCrc32: uncompressedCrc32,
-        filePermissions: parseFilePermissions(externalFileAttr.int shr 16)
+        filePermissions: parseFilePermissions((externalFileAttr.uint shr 16).int)
       )
   except IOError as e:
     result.close()


### PR DESCRIPTION
I experience a very similar issue as #3 but when using `extractAll` for zip archives. My error message was
 
    value out of range: 2323877985 notin -2147483648 .. 2147483647 [RangeDefect]

This PR fixes the issue, but I am not sure if there are other implications with the uint cast.