### PR TITLE
Update gzip.nim

### DIFF
--- a/src/zippy/gzip.nim
+++ b/src/zippy/gzip.nim
@@ -73,5 +73,5 @@ proc uncompressGzip*(
   if checksum != crc32(dst):
     raise newException(ZippyError, "Checksum verification failed")
 
-  if isize != (dst.len mod (1 shl 32)).uint32:
+  if isize != (dst.len mod (1 shl 31)).uint32:
     raise newException(ZippyError, "Size verification failed")


### PR DESCRIPTION
Seems to fix x86 support for gZip (causes a [DivByZeroDefect] error)
I mentioned this in an [issue](https://github.com/guzba/zippy/issues/94)
Ran tests with nimble test, all tests passed.
If this introduces any flaws or issues, just deny it, I'm not experienced w/ this